### PR TITLE
requirements.txt updated to require numpy version < 2

### DIFF
--- a/Python/requirements.txt
+++ b/Python/requirements.txt
@@ -1,3 +1,3 @@
-numpy
+numpy<2
 matplotlib>=2.2.0
  


### PR DESCRIPTION
As it stands right now, Rbeast is not compatible with numpy versions 2.X.X. Requirements.txt has been updated to require pip to install a compatible version of numpy. 