### PR TITLE
Improved Matplotlib version checking for Python code

### DIFF
--- a/Python/py_src/Rbeast/plotbeast.py
+++ b/Python/py_src/Rbeast/plotbeast.py
@@ -3,7 +3,7 @@ from    matplotlib       import __version__  as version
 from   .extractbeast     import extract as extractbeast
 from numpy               import ndarray, min, max,ndarray,flip, isnan, round, sum, arange
 from numpy               import concatenate as c, array as np_array, where as np_where, sqrt as np_sqrt
-
+import pkg_resources
 import warnings
 
 VARS    = ['st', 's', 't', 'scp', 'tcp', 'sorder', 'torder', 'error', 'o', 'ocp', 'samp', 'tslp', 'slpsgn']
@@ -562,7 +562,7 @@ def plot_o(h, ytitle, has, clr, x, t, t2t, Y, CI, ncp, cp):
     # points( t,   Y,    type = 'l',col='#333333');
     # TypeError: stem() got an unexpected keyword argument 'use_line_collection'
     # https://matplotlib.org/3.1.0/api/_as_gen/matplotlib.pyplot.stem.html
-    if version <= '3.3':
+    if pkg_resources.parse_version(version) <= pkg_resources.parse_version('3.3'):
          h.stem( t, Y,  linefmt='-', markerfmt=None ,use_line_collection=True)
     else: 
          h.stem( t, Y,  linefmt='-', markerfmt=None)
@@ -573,7 +573,7 @@ def plot_oprob(h, ytitle, has, clr, x, t, t2t, Prob1, Prob, ncp, cp):
     #% plot(c(t2t[1], t2t), c(0.22, Prob1), type='n', ann=FALSE, xaxt='n', yaxt='n');
    #   # polygon(t2t, Prob1, col  = rgb(col[1],col[2],col[3],alpha), border = NA);
    #    # points( t,   Prob,  col  = rgb(col[1],col[2],col[3])  ,       lwd = 1,type = 'l' );
-    if version >= '3.3':
+    if pkg_resources.parse_version(version) <= pkg_resources.parse_version('3.3'):
          h.stem(t, Prob,  linefmt='-', markerfmt=None,use_line_collection=True)
     else: 
          h.stem(t, Prob,  linefmt='-', markerfmt=None)
@@ -582,7 +582,7 @@ def plot_oprob(h, ytitle, has, clr, x, t, t2t, Prob1, Prob, ncp, cp):
 def plot_error(h, ytitle, has, clr, x, t, t2t, Yerr):
     #% plot(t, Yerr, type='n', ann=FALSE, xaxt='n', yaxt='n');
     h.plot(t, t - t, color=clr);
-    if version <= '3.3':
+    if pkg_resources.parse_version(version) <= pkg_resources.parse_version('3.3'):
          h.stem(t, Yerr, linefmt='-', markerfmt=None,use_line_collection=True)
     else: 
          h.stem(t, Yerr, linefmt='-', markerfmt=None)


### PR DESCRIPTION
I'm installing Rbeast with Python 3.12 and Matplotlib 3.10.1, and the logic for checking the Matplotlib version is failing. As a result, the plotting code tries to incorrectly use the "use_line_collection=True" option that no longer exists. So, I'd like to suggest an improved approach for version checking and I've also created consistency for the three lines where the version is checked. Sam